### PR TITLE
fix: User Management and Ingest Api table pagination

### DIFF
--- a/ui/src/components/ingest-api/IngestTable.tsx
+++ b/ui/src/components/ingest-api/IngestTable.tsx
@@ -23,7 +23,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 
 import { useApi } from "@/api";
-import { HEADERS, ITEMS_PER_PAGE } from "@/constants/ingest-api";
+import { HEADERS } from "@/constants/ingest-api";
 import { useStore } from "@/context/store";
 
 import StatusIndicator from "../upload/StatusIndicator";
@@ -61,10 +61,10 @@ function IngestTable() {
     refetch: refetchSchoolList,
     isRefetching: isSchoolListRefetching,
   } = useQuery({
-    queryKey: ["school_list", currentPage],
+    queryKey: ["school_list", currentPage, pageSize],
     queryFn: () =>
       api.qos.list_school_list({
-        count: ITEMS_PER_PAGE,
+        count: pageSize,
         page: currentPage,
       }),
   });
@@ -144,6 +144,17 @@ function IngestTable() {
     });
   }, [schoolListData, loadingStates]);
 
+  const handleChangePageSize = ({
+    pageSize,
+    page,
+  }: {
+    pageSize: number;
+    page: number;
+  }) => {
+    setCurrentPage(page);
+    setPageSize(pageSize);
+  };
+
   if (isSchoolListLoading) return <DataTableSkeleton headers={HEADERS} />;
 
   return (
@@ -199,16 +210,7 @@ function IngestTable() {
               pageSize={pageSize}
               pageSizes={[10, 25, 50]}
               totalItems={schoolListQuery?.data.total_count}
-              onChange={({
-                pageSize,
-                page,
-              }: {
-                pageSize: number;
-                page: number;
-              }) => {
-                setCurrentPage(page);
-                setPageSize(pageSize);
-              }}
+              onChange={handleChangePageSize}
             />
           </TableContainer>
         )}


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Page size was fixed to `ITEMS_PER_PAGE` constant. Updated to keep track of the selected page size

## How to test

0. [Optional]
```
  <Pagination
              page={currentPage}
              pageSize={pageSize}
              pageSizes={[2, 4, 5]}   // modify this for smaller page sizes for testing
              totalItems={schoolListQuery?.data.total_count}
              onChange={handleChangePageSize}
            />
```
1. Add multiple entries in ingest api
2. Assert that changing the pagesize works

https://github.com/unicef/giga-data-ingestion/assets/122899250/d198e083-8c38-4b06-b4e7-e16dccffd491


