### PR TITLE
fix: update view dq checks to allow dynamic check names

### DIFF
--- a/ui/src/types/upload.ts
+++ b/ui/src/types/upload.ts
@@ -7,21 +7,18 @@ export interface Check {
   count_overall: number;
   percent_failed: number;
   percent_passed: number;
+  dq_remarks: string;
+}
+
+interface Summary {
+  rows: number;
+  columns: number;
+  timestamp: Date;
 }
 
 export interface DataQualityCheckSummary {
-  summary: {
-    rows: number;
-    columns: number;
-    timestamp: Date;
-  };
-  format_validation_checks: Check[];
-  completeness_checks: Check[];
-  domain_checks: Check[];
-  range_checks: Check[];
-  duplicate_rows_checks: Check[];
-  geospatial_checks: Check[];
-  critical_error_check: Check[];
+  [key: string]: Check[] | Summary;
+  summary: Summary;
 }
 
 export interface DqFailedRowValues {


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Updates viewing the data-quality-checks logic to allow any data quality check name

## How to test

1. Upload a new dataset that may not contain the following errors
```
    format_validation_checks,
      completeness_checks,
      domain_checks,
      range_checks,
      duplicate_rows_checks,
      geospatial_checks,
```
2. Assert that viewing the data quality checks is still possible 

## Link to Jira/Asana/Airtable task (if applicable)

https://app.asana.com/0/1206270489214055/1207122359089527

## Wireframe screenshot/screencap (if applicable)


https://github.com/unicef/giga-data-ingestion/assets/122899250/0b5497c9-795c-47eb-9785-3ac4464a1334



