### PR TITLE
fix(ui,api): allow date_format to have empty string

### DIFF
--- a/ui/src/components/ingest-api/SchoolConnectivityFormInputs.tsx
+++ b/ui/src/components/ingest-api/SchoolConnectivityFormInputs.tsx
@@ -231,6 +231,12 @@ export function SchoolConnectivityFormInputs() {
           required: false,
           helperText:
             "If the API requires a date parameter, specify the name of the record where this date should be sent.",
+          onChange: e => {
+            // @ts-expect-error text field has e.target.value, TODO: figure out what the correct type is
+            if (e?.target.value === "") {
+              resetField("date_format");
+            }
+          },
         },
         {
           name: "date_format",

--- a/ui/src/types/ingestApi.ts
+++ b/ui/src/types/ingestApi.ts
@@ -1,3 +1,5 @@
+import { SyntheticEvent } from "react";
+
 import { GraphUser } from "@/types/user.ts";
 
 export type IngestApiFormMapping<T> = {
@@ -6,7 +8,7 @@ export type IngestApiFormMapping<T> = {
   helperText: string;
   required: boolean;
   placeholder?: string;
-  onChange?: (...args: unknown[]) => void;
+  onChange?: (e?: SyntheticEvent) => void;
   dependsOnName?: Extract<keyof T, string>;
   dependsOnValue?: string[] | true;
   customValidation?:


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Adds handling in case users touch `date_format` field in `school connectivity form`


## How to test

1. Go through add api ingestion flow
2. Fill up `date_key` and `date_format`
3. Clear `date_key`
4. Assert that an error occurs when you submit
5. Fill `date_key` then clear `date_format` and `date_key` respectively
6. Assert that you can submit



## Implementation screenshot/screencap (if applicable)


https://github.com/unicef/giga-data-ingestion/assets/122899250/2e6028c2-d399-46db-9aad-1d57a0efeaa5

