### PR TITLE
fix(ui): disable rhf devtools

### DIFF
--- a/ui/src/components/ingest-api/SchoolConnectivity.tsx
+++ b/ui/src/components/ingest-api/SchoolConnectivity.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 
 import { ArrowLeft, ArrowRight } from "@carbon/icons-react";
@@ -11,7 +11,6 @@ import { ZodError } from "zod";
 import ConfirmAddIngestionModal from "@/components/ingest-api/ConfirmAddIngestionModal.tsx";
 import ConfirmEditIngestionModal from "@/components/ingest-api/ConfirmEditIngestionModal.tsx";
 import SchoolConnectivityFormInputs from "@/components/ingest-api/SchoolConnectivityFormInputs.tsx";
-import { ReactHookFormDevTools } from "@/components/utils/DevTools.tsx";
 import { useStore } from "@/context/store.ts";
 import {
   SchoolConnectivityFormSchema,
@@ -73,7 +72,6 @@ function SchoolConnectivity({
     formState: { errors },
     handleSubmit,
     getValues,
-    control,
     clearErrors,
     setError,
   } = hookForm;
@@ -232,12 +230,12 @@ function SchoolConnectivity({
       ) : (
         <ConfirmAddIngestionModal open={open} setOpen={setOpen} />
       )}
-      <Suspense>
+      {/* <Suspense>
         <ReactHookFormDevTools
           // @ts-expect-error incorrect type inference
           control={control}
         />
-      </Suspense>
+      </Suspense> */}
     </Section>
   );
 }

--- a/ui/src/components/ingest-api/SchoolListing.tsx
+++ b/ui/src/components/ingest-api/SchoolListing.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 
 import { ArrowLeft, ArrowRight } from "@carbon/icons-react";
@@ -15,7 +15,6 @@ import {
 } from "@/api/queryOptions.ts";
 import IngestFormSkeleton from "@/components/ingest-api/IngestFormSkeleton.tsx";
 import SchoolListFormInputs from "@/components/ingest-api/SchoolListFormInputs.tsx";
-import { ReactHookFormDevTools } from "@/components/utils/DevTools.tsx";
 import { useStore } from "@/context/store.ts";
 import { SchoolListFormSchema, TestApiSchema } from "@/forms/ingestApi.ts";
 import { useTestApi } from "@/hooks/useTestApi.ts";
@@ -72,7 +71,6 @@ function SchoolListing({ isEditing = false, defaultData }: SchoolListingProps) {
 
   const {
     handleSubmit,
-    control,
     formState: { errors },
     setError,
     getValues,
@@ -232,13 +230,13 @@ function SchoolListing({ isEditing = false, defaultData }: SchoolListingProps) {
       </div>
 
       <Outlet />
-
+      {/* 
       <Suspense>
         <ReactHookFormDevTools
           // @ts-expect-error incorrect type inference
           control={control}
         />
-      </Suspense>
+      </Suspense> */}
     </Section>
   );
 }

--- a/ui/src/routes/upload/$uploadGroup/$uploadType/column-mapping.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/column-mapping.tsx
@@ -1,5 +1,5 @@
-import { Suspense, useMemo } from "react";
-import { Control, FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import { useMemo } from "react";
+import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 
 import { ArrowLeft, ArrowRight, Warning } from "@carbon/icons-react";
 import { Button, ButtonSet, DataTableHeader, Stack, Tag } from "@carbon/react";
@@ -21,7 +21,6 @@ import {
   DetectedColumn,
   MasterColumn,
 } from "@/components/upload/ColumnMapping.tsx";
-import { ReactHookFormDevTools } from "@/components/utils/DevTools.tsx";
 import { useStore } from "@/context/store";
 
 export const Route = createFileRoute(
@@ -90,7 +89,7 @@ function UploadColumnMapping() {
     },
     shouldFocusError: true,
   });
-  const { handleSubmit, control } = hookForm;
+  const { handleSubmit } = hookForm;
 
   const onSubmit: SubmitHandler<ConfigureColumnsForm> = data => {
     const dataWithNullsReplaced: ConfigureColumnsForm = {
@@ -139,10 +138,10 @@ function UploadColumnMapping() {
           <section className="w-3/4">
             <DataTable columns={headers} rows={rows} />
           </section>
-
+          {/* 
           <Suspense>
             <ReactHookFormDevTools control={control as unknown as Control} />
-          </Suspense>
+          </Suspense> */}
 
           <ButtonSet className="w-full">
             <Button

--- a/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   FieldErrors,
   SubmitHandler,
@@ -35,7 +35,6 @@ import {
   SelectFromArray,
   SelectFromEnum,
 } from "@/components/upload/MetadataInputs.tsx";
-import { ReactHookFormDevTools } from "@/components/utils/DevTools.tsx";
 import { metadataMapping, yearList } from "@/constants/metadata";
 import { useStore } from "@/context/store";
 import useRoles from "@/hooks/useRoles.ts";
@@ -161,7 +160,6 @@ function Metadata() {
   const {
     register,
     handleSubmit,
-    control,
     formState: { errors },
   } = useForm<MetadataForm>({
     mode: "onSubmit",
@@ -335,9 +333,9 @@ function Metadata() {
           </Stack>
         </Form>
 
-        <Suspense>
+        {/* <Suspense>
           <ReactHookFormDevTools control={control} />
-        </Suspense>
+        </Suspense> */}
       </Section>
     </Section>
   );

--- a/ui/src/routes/user-management/user/edit.$userId.tsx
+++ b/ui/src/routes/user-management/user/edit.$userId.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 
 import { Add } from "@carbon/icons-react";
@@ -25,7 +25,6 @@ import { ErrorComponent } from "@/components/common/ErrorComponent.tsx";
 import { PendingComponent } from "@/components/common/PendingComponent.tsx";
 import { Select } from "@/components/forms/Select.tsx";
 import ToastNotification from "@/components/user-management/ToastNotification.tsx";
-import { ReactHookFormDevTools } from "@/components/utils/DevTools.tsx";
 import countries from "@/constants/countries.ts";
 import {
   filterCountries,
@@ -482,10 +481,10 @@ function EditUser() {
         </Modal>
       )}
 
-      <Suspense>
-        {/* @ts-expect-error inference */}
+      {/* <Suspense>
+        //@ts-expect-error inference
         <ReactHookFormDevTools control={control} />
-      </Suspense>
+      </Suspense> */}
 
       <ToastNotification
         show={showEditUserSuccessNotification}


### PR DESCRIPTION
## What type of PR is this?
- `fix`: Commits that fix a bug

## Summary

Disables RHF devtools by default which slows down the upload flow's column mapping form 🐢.

## How to test

1. Go through upload flow
2. Assert that the column mapping page is no longer slow
