### PR TITLE
fix(ui): update datetime regex

### DIFF
--- a/ui/src/forms/ingestApi.ts
+++ b/ui/src/forms/ingestApi.ts
@@ -117,11 +117,7 @@ export const SchoolConnectivityFormSchema = CommonApiIngestionFormSchema.extend(
     date_format: z
       .union([
         z.enum(["timestamp", "ISO8601"]),
-        z
-          .string()
-          .regex(
-            /^(%Y|%m|%d|%H|%M|%S|%z)([\\/\\-_.+: ]?(%Y|%m|%d|%H|%M|%S|%z))?$/,
-          ),
+        z.string().regex(/^(%[YmdHMSz])([\\\-_.+: ]%[YmdHMSz])*$/),
       ])
       .nullable(),
     school_id_send_query_in: z.nativeEnum(SendQueryInEnum),


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Updates datetime regex logic. Old logic only allowed for 0 or one repetition of a sequnce which is why a sequence with two reptitions like `%Y-%m-%d` failed

## How to test

1. Go through the school api flow, using the `https://api.simet.nic.br/school-measures/v1/getMeasuresbyDayofYear` for school connectivity
2. Assert that you can submit an ingestion with the request date format `%Y-%m-%d`


## Implementation screenshot/screencap (if applicable)

https://github.com/unicef/giga-data-ingestion/assets/122899250/953d6af2-d827-40c6-a3de-8293fa458620



