### PR TITLE
fix(ui): make test api logic less strict

### DIFF
--- a/ui/src/hooks/useTestApi.ts
+++ b/ui/src/hooks/useTestApi.ts
@@ -115,16 +115,16 @@ export function useTestApi() {
         setResponsePreview(responseData);
 
         if (data_key === "" || data_key == null) {
+          setIsValidDataKey(true);
+          setIsValidResponse(true);
+          setIsResponseError(false);
+
           if (Object.prototype.hasOwnProperty.call(responseData, "")) {
             formattedResponseData = [responseData[""]];
             setResponsePreview(formattedResponseData);
           }
 
           if (Array.isArray(formattedResponseData)) {
-            setIsValidDataKey(true);
-            setIsValidResponse(true);
-            setIsResponseError(false);
-
             if (apiType === "schoolList") {
               if (school_id_key) {
                 const testSchoolIdKey = getTestSchoolId(
@@ -146,8 +146,6 @@ export function useTestApi() {
               );
             }
           } else {
-            setIsValidDataKey(false);
-
             if (apiType === "schoolConnectivity") {
               setIsValidGigaGovtSchoolIdKey(
                 Object.keys(formattedResponseData).includes(
@@ -158,11 +156,18 @@ export function useTestApi() {
           }
 
           if (apiType === "schoolConnectivity") {
-            if (response_date_key) {
-              const responseDateKeyValue = formattedResponseData[0][
+            let responseDateKeyValue;
+
+            if (Array.isArray(formattedResponseData)) {
+              responseDateKeyValue = formattedResponseData[0][
                 response_date_key ?? ""
               ] as string;
-
+            } else {
+              responseDateKeyValue = formattedResponseData[
+                response_date_key ?? ""
+              ] as string;
+            }
+            if (response_date_key) {
               const castResponseDateKeyValue = String(responseDateKeyValue);
 
               if (response_date_format === "timestamp") {


### PR DESCRIPTION
## What type of PR is this?

- `feat`: Commits that add a new feature

## Summary


Liquid enpoint response is a top level array.
Adjusted `Test API` logic to accept and process top level arrays even if `data_key` provided is null.

```
{
  "school_id": "46K2",
  ...
  "pe_ingress": 7.78,
  "pe_egress": 17.34
}
```

Before: Assumption was if response was NOT a top level array, a `data_key` would be expected


## How to test

1. Instructions on how to test
2. Specify which files to review
3. etc.


## Implementation screenshot/screencap (if applicable)

Liquid

https://github.com/unicef/giga-data-ingestion/assets/122899250/d05ccccd-b255-447b-8fbd-4407c9c95e31

Nic.br

https://github.com/unicef/giga-data-ingestion/assets/122899250/2eda4f67-f006-4618-ac31-498f3d80916f
