### PR TITLE
fix: make all unicef and tm emails admin

### DIFF
--- a/api/data_ingestion/internal/roles.py
+++ b/api/data_ingestion/internal/roles.py
@@ -1,11 +1,11 @@
 from uuid import uuid4
 
 from fastapi_azure_auth.user import User as AzureUser
-from sqlalchemy import exists, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from data_ingestion.models import Role, User, UserRoleAssociation
+from data_ingestion.models import Role, User
 
 
 async def create_user_if_not_exist_and_assign_roles(
@@ -18,20 +18,11 @@ async def create_user_if_not_exist_and_assign_roles(
         surname=surname,
     )
 
-    does_admin_exist = not await db.scalar(
-        select(
-            exists().where(UserRoleAssociation.role_id == Role.id, Role.name == "Admin")
-        )
-    )
-
-    if (
-        any(
-            [
-                email.endswith("@thinkingmachin.es"),
-                email.endswith("@unicef.org"),
-            ]
-        )
-        and does_admin_exist
+    if any(
+        [
+            email.endswith("@thinkingmachin.es"),
+            email.endswith("@unicef.org"),
+        ]
     ):
         admin_role = await db.scalar(select(Role).where(Role.name == "Admin"))
         new_user.roles.add(admin_role)


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary


All new TM or GIGa emails are immediately given admin roles upon first login.

This changes the previous setup where only the first TM or GIGA user that logs in gets an admin role


## How to test

1. Clear the `users` table in the database
2. Login with a TM and another non TM/GIGA account. This ensures that an account with a TM admin and a non-TM, non-admin account exsists
3. Give admin perms to the non TM account and delete the TM user
4. Login again with the TM user and assert that the TM user still has admin perms

## Link to Jira/Asana/Airtable task (if applicable)

https://app.asana.com/0/1207713905378556/1208004994733811


