### PR TITLE
feat: [R-38] send dq reports to admins

### DIFF
--- a/api/data_ingestion/internal/email.py
+++ b/api/data_ingestion/internal/email.py
@@ -45,10 +45,7 @@ def send_email_base(
 
     formatted_recipients = [{"Email": r} for r in recipients]
 
-    if len(recipients) > 1:
-        message["Bcc"] = formatted_recipients
-    else:
-        message["Recipients"] = formatted_recipients
+    message["Recipients"] = formatted_recipients
 
     client = Client(
         auth=(settings.MAILJET_API_KEY, settings.CLEAN_MAILJET_SECRET),


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

- Removes `BCC` usage when sending emails. Using `To` `CC` or `BCC` does not work with current implem. [usage defined here](https://dev.mailjet.com/email/guides/send-api-V3/)
- Uses recepients for both single and multiple recipients. Other recepients are not seein in the email so it emulates bcc behaviour.

## How to test

Must be merged with https://github.com/unicef/giga-dagster/pull/285

1. Have a non admin and an admin account on hand
2. Go through the upload flow
3. Assert that both you (the uploader) and an admin account receives the DQ report email

## Link to Jira/Asana/Airtable task (if applicable)

https://app.asana.com/0/1207713905378556/1208165477249482

![image](https://github.com/user-attachments/assets/120e43a9-7af1-4ba7-be67-d844e93b8e3d)

![image](https://github.com/user-attachments/assets/e8bb99a2-7797-4433-8c27-881d9605f471)
