### PR TITLE
fix: render 0 rows as null

### DIFF
--- a/ui/src/components/check-file-uploads/SummaryChecks.tsx
+++ b/ui/src/components/check-file-uploads/SummaryChecks.tsx
@@ -24,24 +24,24 @@ const SummaryChecks = ({
       </span>
       <span>File uploaded at {uploadTimestamp}</span>
       <span>Checks performed at {checkTimestamp}</span>
-      {rows && (
+      {rows ? (
         <span>
           Count of schools in raw file:{" "}
           <span className="font-bold">{commaNumber(rows)}</span>
         </span>
-      )}
-      {rowsPassed && (
+      ) : null}
+      {rowsPassed ? (
         <span>
           Count of schools for approval (Uploaded Schools):{" "}
           <span className="font-bold">{commaNumber(rowsPassed)}</span>
         </span>
-      )}
-      {rowsFailed && (
+      ) : null}
+      {rowsFailed ? (
         <span>
           Count of schools dropped (Not Uploaded):{" "}
           <span className="font-bold">{commaNumber(rowsFailed)}</span>
         </span>
-      )}
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug


## Summary

`rowsFailed` = 0  is still being rendered since it is neither `boolean` nor `undefined`
https://stackoverflow.com/questions/53048037/react-showing-0-instead-of-nothing-with-short-circuit-conditional-component 
