### PR TITLE
fix: add null file error messages

### DIFF
--- a/ui/src/routes/upload/$uploadGroup/$uploadType/column-mapping.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/column-mapping.tsx
@@ -72,6 +72,7 @@ const headers: DataTableHeader[] = [
 function UploadColumnMapping() {
   const {
     uploadSlice: {
+      file,
       detectedColumns,
       columnMapping,
       source,
@@ -82,6 +83,7 @@ function UploadColumnMapping() {
   } = useStore();
   const [isPrivacyLoading, setIsPrivacyLoading] = useState(false);
   const [isNavigating, setIsNavigating] = useState(false);
+  const [isNullFile, setIsNullFile] = useState(false);
   const [selectedColumns, setSelectedColumns] =
     useState<Record<string, string>>(columnMapping);
 
@@ -121,6 +123,11 @@ function UploadColumnMapping() {
     setColumnLicense(dataWithNullsReplaced.license);
     setStepIndex(2);
     setIsNavigating(true);
+
+    if (file == null) {
+      setIsNullFile(true);
+    }
+
     void navigate({ to: "../metadata" });
   };
 
@@ -234,6 +241,11 @@ function UploadColumnMapping() {
               Proceed
             </Button>
           </ButtonSet>
+          {isNullFile && (
+            <div className="text-giga-red">
+              File is missing at this step, please upload the file again
+            </div>
+          )}
         </Stack>
       </form>
     </FormProvider>

--- a/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
@@ -152,6 +152,7 @@ function Metadata() {
 
   const [isUploading, setIsUploading] = useState<boolean>(false);
   const [isUploadError, setIsUploadError] = useState<boolean>(false);
+  const [isNullFile, setIsNullFile] = useState<boolean>(false);
 
   const {
     register,
@@ -193,6 +194,10 @@ function Metadata() {
   }
 
   const onSubmit: SubmitHandler<MetadataForm> = async data => {
+    if (uploadSlice.file === null) {
+      setIsNullFile(true);
+    }
+
     if (Object.keys(errors).length > 0) {
       // form has errors, don't submit
       return;
@@ -335,6 +340,11 @@ function Metadata() {
             {isUploadError && (
               <div className="text-giga-dark-red">
                 Error occurred during file upload. Please try again
+              </div>
+            )}
+            {isNullFile && (
+              <div className="text-giga-red">
+                File is missing at this step, please upload the file again
               </div>
             )}
           </Stack>


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Add error messages in the upload flow in case the `file` has been stripped out accidentally.
These are temporary error messages meant to investigate why the `file` is being stripped out

