### PR TITLE
fix: query the oldest available commit in approval_requests

### DIFF
--- a/api/data_ingestion/routers/approval_requests.py
+++ b/api/data_ingestion/routers/approval_requests.py
@@ -110,8 +110,11 @@ async def list_approval_requests(
     queries = []
     for table in staging_tables:
         min_version = db.execute(
-            select(func.min(column("version")))
-            .select_from(text(f'''delta_lake.{table['table_schema']}."{table['table_name']}$history"'''))
+            select(func.min(column("version"))).select_from(
+                text(
+                    f'''delta_lake.{table['table_schema']}."{table['table_name']}$history"'''
+                )
+            )
         ).scalar()
 
         change_types_cte = (
@@ -124,7 +127,7 @@ async def list_approval_requests(
                     func.delta_lake.system.table_changes(
                         literal(table["table_schema"]),
                         literal(table["table_name"]),
-                        literal(min_version)
+                        literal(min_version),
                     )
                 )
             )


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Changes the CTE in approval_requests.py to query table changes from the oldest available Delta Lake commit instead of commit version 0. This fixes the `DELTA_LAKE_BAD_DATA` error that appears upon loading the Approval Requests page.

## How to test

1. Simulate an incomplete Delta Lake log by deleting past versions from one of the countries in `school_geolocation_staging.db`
2. Load the Approval Requests page in the frontend. Validate that the requests still appear correctly.