### PR TITLE
fix: set correct env for sentry

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -21,7 +21,7 @@ import App from "@/app.tsx";
 import { msalInstance } from "@/lib/auth.ts";
 import "@/styles/index.scss";
 
-if (import.meta.env.SENTRY_DSN && import.meta.env.PROD) {
+if (import.meta.env.VITE_SENTRY_DSN && import.meta.env.PROD) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
     integrations: [


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Currently, Sentry is enabled for `ui` only if the `SENTRY_DSN` env variable is set. However, the code actually makes use of the `VITE_SENTRY_DSN` env variable. This fix aligns both variables such that only `VITE_SENTRY_DSN` needs to be set.

## How to test

With the `VITE_SENTRY_DSN` env variable set, test that you can receive exceptions in the `ui` component in your Sentry dashboard.