### PR TITLE
fix: empty detected columns

### DIFF
--- a/ui/src/routes/upload/$uploadGroup/$uploadType/index.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { ArrowLeft, ArrowRight } from "@carbon/icons-react";
@@ -116,6 +116,23 @@ export default function Index() {
   });
 
   const schema = schemaQuery?.data ?? [];
+
+  useEffect(() => {
+    const { file } = uploadSlice;
+    if (schema.length && file) {
+      const detector = new HeaderDetector({
+        file,
+        schema,
+        setIsParsing: setIsParsing,
+        setError: setParsingError,
+        setColumnMapping,
+        setDetectedColumns,
+        type: validTypes[file.type as keyof typeof validTypes],
+      });
+      detector.validateFileSize();
+      detector.detect();
+    }
+  }, [schema]);
 
   const handleProceedToNextStep = () => {
     if (file) {


### PR DESCRIPTION
Fix the detected columns dropdowns being empty in Step 2 when the file is selected first before a selection is made on the mode/source dropdown in Step 1.

## What type of PR is this?


- `fix`: Commits that fix a bug


## Summary
In step one of both geolocation or coverage selecting a file before selecting an option in the dropdown results in the detected columns dropdowns on the next step to be empty. This PR fixes this issue.

## How to test

1. Login to Giga Sync
2. Click school geolocation
3. Select a file to upload
4. Select an option from the dropdown
5. Expect the detected columns dropdown to have a default value based on the uploaded file

(repeat the test steps for school coverage)

