### PR TITLE
chore: move giga assets to giga owned storage

### DIFF
--- a/email/src/components/DqReportHeading.tsx
+++ b/email/src/components/DqReportHeading.tsx
@@ -13,8 +13,8 @@ function DqReportHeading({ hasCriticalError, title }: DqReportHeaderProps) {
         className="w-10 h-10 mr-2 -mt-1"
         src={`${
           hasCriticalError
-            ? "https://storage.googleapis.com/giga-assets/MisuseOutlineRed.png"
-            : "https://storage.googleapis.com/giga-assets/MisuseOutlineYellow.png"
+            ? "https://saunigigashare.blob.core.windows.net/assets/MisuseOutlineRed.png"
+            : "https://saunigigashare.blob.core.windows.net/assets/MisuseOutlineYellow.png"
         }`}
       />
       <strong

--- a/email/src/components/Header.tsx
+++ b/email/src/components/Header.tsx
@@ -8,7 +8,7 @@ function Header() {
           className="p-4"
           width={40}
           height={40}
-          src="https://storage.googleapis.com/giga-assets/GIGA_logo.png"
+          src="https://saunigigashare.blob.core.windows.net/assets/GIGA_logo.png"
         />
       </Column>
       <Column>

--- a/email/src/emails/dq-report-check-success.tsx
+++ b/email/src/emails/dq-report-check-success.tsx
@@ -51,7 +51,7 @@ export const DataQualityReportCheckSuccess = ({
               <Heading className="flex align-middle p-0 text-2xl font-normal text-giga-green">
                 <Img
                   className="w-10 h-10 mr-2 -mt-1"
-                  src="https://storage.googleapis.com/giga-assets/CheckmarkOutlineGreen.png"
+                  src="https://saunigigashare.blob.core.windows.net/assets/CheckmarkOutlineGreen.png"
                 />
                 <strong>Data check successful</strong>
               </Heading>


### PR DESCRIPTION
## What type of PR is this?

- `chore`: Miscellaneous commits (e.g. modifying `.gitignore`)

## Summary

Move spark installer to giga owned storage bucket

## How to test

1. Go localhost:3030 to access the react-email ui
2. Try sending a test email to yourself
3. Inspect the email and assert that the src atribbute of the <img> tag points to the new location