### PR TITLE
fix: add ODBL license option and set it as the default license

### DIFF
--- a/ui/src/mocks/metadataFormValues.tsx
+++ b/ui/src/mocks/metadataFormValues.tsx
@@ -17,4 +17,4 @@ export const sourceOptions = [
   { label: "Meta", value: "fb" },
 ];
 
-export const licenseOptions = ["ODBL","Giga Analysis"];
+export const licenseOptions = ["ODBL", "Giga Analysis"];


### PR DESCRIPTION
## What type of PR is this?
Change the default license to ODBL instead of Giga Analysis.
## Summary
Updated the default license from "Giga Analysis" to "ODBL," aligning with project requirements and ensuring compliance with preferred licensing standards.




