### PR TITLE
Fix/Upload custom prod datasets to the data lake (prod container) via Giga Sync

### DIFF
--- a/ui/src/api/routers/uploads.ts
+++ b/ui/src/api/routers/uploads.ts
@@ -5,6 +5,7 @@ import {
   BasicChecks,
   DataQualityCheck,
   UploadParams,
+  UploadStructuredParams,
   UploadUnstructuredParams,
 } from "@/types/upload";
 import { UploadResponse } from "@/types/upload.ts";
@@ -49,6 +50,19 @@ export default function routes(axi: AxiosInstance) {
       });
 
       return axi.post("/upload/unstructured", formData);
+    },
+
+    upload_structured: (
+      params: UploadStructuredParams,
+    ): Promise<AxiosResponse<null>> => {
+      const formData = new FormData();
+      Object.entries(params).forEach(([key, value]) => {
+        if (value != null) {
+          formData.append(key, value);
+        }
+      });
+
+      return axi.post("/upload/structured", formData);
     },
 
     download_data_quality_check: (params: {

--- a/ui/src/components/upload/UploadLanding.tsx
+++ b/ui/src/components/upload/UploadLanding.tsx
@@ -107,7 +107,7 @@ function UploadLanding(props: UploadLandingProps) {
                 size="xl"
                 renderIcon={Add}
               >
-                Unstructured dataset
+                Schemaless dataset
               </Button>
             </div>
           </Stack>

--- a/ui/src/components/upload/UploadLanding.tsx
+++ b/ui/src/components/upload/UploadLanding.tsx
@@ -98,10 +98,10 @@ function UploadLanding(props: UploadLandingProps) {
               )}
               <Button
                 as={Link}
-                to="/upload/$uploadGroup/$uploadType"
+                to="/upload/$uploadGroup/options/$uploadType"
                 params={{
                   uploadGroup: "other",
-                  uploadType: "unstructured",
+                  uploadType: "schemaless",
                 }}
                 className="w-full"
                 size="xl"

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as IngestApiEditIngestionIdIndexImport } from './routes/ingest-ap
 import { Route as UserManagementUserRevokeUserIdImport } from './routes/user-management/user/revoke.$userId'
 import { Route as UserManagementUserEnableUserIdImport } from './routes/user-management/user/enable.$userId'
 import { Route as UserManagementUserEditUserIdImport } from './routes/user-management/user/edit.$userId'
+import { Route as UploadUploadGroupOptionsUploadTypeImport } from './routes/upload/$uploadGroup/options.$uploadType'
 import { Route as UploadUploadGroupUploadTypeSuccessImport } from './routes/upload/$uploadGroup/$uploadType/success'
 import { Route as UploadUploadGroupUploadTypeMetadataImport } from './routes/upload/$uploadGroup/$uploadType/metadata'
 import { Route as UploadUploadGroupUploadTypeColumnMappingImport } from './routes/upload/$uploadGroup/$uploadType/column-mapping'
@@ -197,6 +198,12 @@ const UserManagementUserEditUserIdRoute =
     getParentRoute: () => UserManagementRoute,
   } as any)
 
+const UploadUploadGroupOptionsUploadTypeRoute =
+  UploadUploadGroupOptionsUploadTypeImport.update({
+    path: '/$uploadGroup/options/$uploadType',
+    getParentRoute: () => UploadLazyRoute,
+  } as any)
+
 const UploadUploadGroupUploadTypeSuccessRoute =
   UploadUploadGroupUploadTypeSuccessImport.update({
     path: '/success',
@@ -339,6 +346,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UploadUploadGroupUploadTypeSuccessImport
       parentRoute: typeof UploadUploadGroupUploadTypeImport
     }
+    '/upload/$uploadGroup/options/$uploadType': {
+      preLoaderRoute: typeof UploadUploadGroupOptionsUploadTypeImport
+      parentRoute: typeof UploadLazyImport
+    }
     '/user-management/user/edit/$userId': {
       preLoaderRoute: typeof UserManagementUserEditUserIdImport
       parentRoute: typeof UserManagementImport
@@ -401,5 +412,6 @@ export const routeTree = rootRoute.addChildren([
       UploadUploadGroupUploadTypeIndexRoute,
     ]),
     UploadUploadIdIndexRoute,
+    UploadUploadGroupOptionsUploadTypeRoute,
   ]),
 ])

--- a/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
@@ -56,8 +56,16 @@ export const Route = createFileRoute(
       uploadSliceActions: { setStepIndex },
     } = getState();
 
-    if (uploadGroup === "other" && uploadType === "unstructured") {
+    const isUnstructured =
+      uploadGroup === "other" && uploadType === "unstructured";
+    const isStructured = uploadGroup === "other" && uploadType === "structured";
+
+    if (isUnstructured) {
       setStepIndex(1);
+    } else if (isStructured) {
+      // Structured datasets should not go through metadata step
+      setStepIndex(0);
+      throw redirect({ from: Route.fullPath, to: ".." });
     } else if (
       !file ||
       Object.values(columnMapping).filter(Boolean).length === 0
@@ -142,6 +150,7 @@ function Metadata() {
 
   const isUnstructured =
     uploadGroup === "other" && uploadType === "unstructured";
+  const isStructured = uploadGroup === "other" && uploadType === "structured";
 
   const { countryDatasets, isPrivileged } = useRoles();
 
@@ -172,6 +181,10 @@ function Metadata() {
     mutationFn: api.uploads.upload_unstructured,
   });
 
+  const uploadStructuredFile = useMutation({
+    mutationFn: api.uploads.upload_structured,
+  });
+
   const { data: allGroupsQuery, isLoading } = useSuspenseQuery({
     queryKey: ["groups"],
     queryFn: api.groups.list,
@@ -189,7 +202,7 @@ function Metadata() {
     ];
   }, [allGroupsQuery?.data]);
   let countryOptions = isPrivileged ? allCountryNames : userCountryNames;
-  if (isUnstructured) {
+  if (isUnstructured || isStructured) {
     countryOptions = ["N/A", ...countryOptions];
   }
 
@@ -207,7 +220,8 @@ function Metadata() {
     setIsUploadError(false);
 
     const metadata = { ...data };
-    const country = metadata.country;
+    // For structured datasets, use "N/A" as default country since they're global
+    const country = isStructured ? "N/A" : metadata.country;
     delete metadata.country;
 
     const columnMapping = uploadSlice.columnMapping;
@@ -238,6 +252,9 @@ function Metadata() {
     try {
       if (isUnstructured) {
         await uploadUnstructuredFile.mutateAsync(body);
+        setUploadDate(uploadSlice.timeStamp);
+      } else if (isStructured) {
+        await uploadStructuredFile.mutateAsync(body);
         setUploadDate(uploadSlice.timeStamp);
       } else {
         const {
@@ -291,7 +308,9 @@ function Metadata() {
                             countryOptions={countryOptions}
                             isLoading={isLoading}
                             errors={errors}
-                            register={register("country", { required: true })}
+                            register={register("country", {
+                              required: !isStructured,
+                            })}
                           />
                         ) : (
                           <RenderFormItem
@@ -312,7 +331,7 @@ function Metadata() {
               <Button
                 kind="secondary"
                 as={Link}
-                to={isUnstructured ? ".." : "../column-mapping"}
+                to={isUnstructured || isStructured ? ".." : "../column-mapping"}
                 onClick={() => setStepIndex(1)}
                 className="w-full"
                 renderIcon={ArrowLeft}

--- a/ui/src/routes/upload/$uploadGroup/$uploadType/success.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/success.tsx
@@ -54,7 +54,18 @@ export const Route = createFileRoute(
       uploadSliceActions: { setStepIndex },
     } = getState();
 
-    if (uploadGroup === "other" && uploadType === "unstructured") {
+    const isUnstructured =
+      uploadGroup === "other" && uploadType === "unstructured";
+    const isStructured = uploadGroup === "other" && uploadType === "structured";
+
+    if (isUnstructured) {
+      return;
+    } else if (isStructured) {
+      // For structured datasets, we don't need column mapping
+      if (!file) {
+        setStepIndex(0);
+        throw redirect({ to: ".." });
+      }
       return;
     } else if (
       !file ||

--- a/ui/src/routes/upload/$uploadGroup/options.$uploadType.tsx
+++ b/ui/src/routes/upload/$uploadGroup/options.$uploadType.tsx
@@ -1,0 +1,101 @@
+import { Add } from "@carbon/icons-react";
+import { Button, Section, Stack } from "@carbon/react";
+import { Link, createFileRoute } from "@tanstack/react-router";
+
+import { ErrorComponent } from "@/components/common/ErrorComponent.tsx";
+import { PendingComponent } from "@/components/common/PendingComponent.tsx";
+
+export const Route = createFileRoute(
+  "/upload/$uploadGroup/options/$uploadType",
+)({
+  component: Options,
+  pendingComponent: PendingComponent,
+  errorComponent: ErrorComponent,
+});
+
+const STRUCTURED_DESCRIPTION = (
+  <>
+    <p>
+      Structured datasets are custom production datasets that will be dumped to
+      raw/custom-dataset/filename.csv in the data lake and will be accessible on
+      Superset via Trino.
+    </p>
+    <p>
+      This option is for datasets that follow a predefined schema and structure.
+    </p>
+  </>
+);
+
+const UNSTRUCTURED_DESCRIPTION = (
+  <>
+    <p>
+      Data such as geospatial and shape files, used to provide geographical
+      information and boundaries which represent the landscape of countries.
+    </p>
+    <p>
+      Any file uploaded must be no larger than 10MB and be in one of the
+      accepted file formats: [bmp, .gif, .jpeg, .jpg, .png, .tif, .tiff, .csv,
+      .xlsx, .xls, .pdf, .doc, .docx]
+    </p>
+  </>
+);
+
+function Options() {
+  const { uploadGroup: _uploadGroup, uploadType: _uploadType } =
+    Route.useParams();
+
+  return (
+    <Section>
+      <Stack gap={8}>
+        <Stack gap={4}>
+          <h1>Choose Dataset Type</h1>
+          <p>Please select the type of dataset you want to upload:</p>
+        </Stack>
+
+        <div className="grid grid-cols-2 gap-6">
+          <div className="rounded-lg border border-gray-200 p-6">
+            <Stack gap={4}>
+              <h2 className="text-xl font-semibold">Structured Dataset</h2>
+              {STRUCTURED_DESCRIPTION}
+              <Button
+                as={Link}
+                to="/upload/$uploadGroup/$uploadType"
+                params={{
+                  uploadGroup: "other",
+                  uploadType: "structured",
+                }}
+                className="w-full"
+                size="xl"
+                renderIcon={Add}
+              >
+                Upload Structured Dataset
+              </Button>
+            </Stack>
+          </div>
+
+          <div className="rounded-lg border border-gray-200 p-6">
+            <Stack gap={4}>
+              <h2 className="text-xl font-semibold">Unstructured Dataset</h2>
+              {UNSTRUCTURED_DESCRIPTION}
+              <Button
+                as={Link}
+                to="/upload/$uploadGroup/$uploadType"
+                params={{
+                  uploadGroup: "other",
+                  uploadType: "unstructured",
+                }}
+                className="w-full"
+                size="xl"
+                renderIcon={Add}
+              >
+                Upload Unstructured Dataset
+              </Button>
+            </Stack>
+          </div>
+        </div>
+      </Stack>
+    </Section>
+  );
+}
+
+export default Options;

--- a/ui/src/routes/upload/$uploadGroup/options.$uploadType.tsx
+++ b/ui/src/routes/upload/$uploadGroup/options.$uploadType.tsx
@@ -16,12 +16,13 @@ export const Route = createFileRoute(
 const STRUCTURED_DESCRIPTION = (
   <>
     <p>
-      Structured datasets are custom production datasets that will be dumped to
-      raw/custom-dataset/filename.csv in the data lake and will be accessible on
-      Superset via Trino.
+      Structured datasets are custom production datasets that follow a
+      predefined schema and structure, designed for analytical queries and
+      reporting.
     </p>
     <p>
-      This option is for datasets that follow a predefined schema and structure.
+      Once uploaded, these datasets will be available for querying and analysis
+      in Superset dashboards and reports.
     </p>
   </>
 );

--- a/ui/src/types/upload.ts
+++ b/ui/src/types/upload.ts
@@ -90,6 +90,13 @@ export interface UploadUnstructuredParams {
   metadata: string;
 }
 
+export interface UploadStructuredParams {
+  country: string;
+  file: File;
+  source?: string | null;
+  metadata: string;
+}
+
 export const DQStatusTagMapping: Record<
   DQStatus,
   ComponentProps<typeof Tag>["type"]


### PR DESCRIPTION
## What type of PR is this?

## Summary

- Rename the **Unstructured Dataset** to **Schemaless Dataset**.
- After clicking on **Schemaless Dataset**, under **Upload**, create two options:
  - **Structured Dataset**
  - **Unstructured Dataset**
- The **Unstructured Dataset** option follows the existing flow and accepts all kinds of file structures — `.csv`, `.xlsx`, `.pdf`, `.tiff`, `.img`, etc.
- The new **Structured Dataset** option is for custom production datasets. It will:
  - Dump the dataset to `raw/custom-dataset/filename.csv` in the data lake.
  - Make the dataset accessible on **Superset** via **Trino**.

### Data Storage
- The dataset needs to be stored as a **CSV** at:  
  `raw/custom-dataset/filename.csv`
