### PR TITLE
fix(ui): [GIGA-42] missing upload file

### DIFF
--- a/ui/src/components/utils/AuthenticatedRBACView.tsx
+++ b/ui/src/components/utils/AuthenticatedRBACView.tsx
@@ -30,13 +30,16 @@ function AuthenticatedRBACView({
 
   return (
     <AuthenticatedView>
-      {isFetching ? (
-        <FullPageLoading />
-      ) : isEnabledAndHasPermissions ? (
-        children
-      ) : (
-        <Forbidden />
-      )}
+      {isFetching && <FullPageLoading />}
+      {!isFetching && !isEnabledAndHasPermissions && <Forbidden />}
+      <div
+        style={{
+          display:
+            isFetching || !isEnabledAndHasPermissions ? "none" : undefined,
+        }}
+      >
+        {children}
+      </div>
     </AuthenticatedView>
   );
 }

--- a/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
@@ -19,6 +19,7 @@ import {
   Tag,
 } from "@carbon/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import * as Sentry from "@sentry/react";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import {
   Link,
@@ -195,7 +196,32 @@ function Metadata() {
 
   const onSubmit: SubmitHandler<MetadataForm> = async data => {
     if (uploadSlice.file === null) {
+      // Log to Sentry with context
+      Sentry.captureException(
+        new Error("File upload attempted with missing file"),
+        {
+          tags: {
+            component: "Metadata",
+            route: "upload-metadata",
+            uploadType,
+            uploadGroup,
+          },
+          extra: {
+            uploadSlice: {
+              hasFile: !!uploadSlice.file,
+              hasColumnMapping: !!uploadSlice.columnMapping,
+              stepIndex: uploadSlice.stepIndex,
+              mode: uploadSlice.mode,
+              source: uploadSlice.source,
+            },
+            formData: data,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      );
+
       setIsNullFile(true);
+      return;
     }
 
     if (Object.keys(errors).length > 0) {


### PR DESCRIPTION

- `fix`: Commits that fix a bug


## Summary

This PR fixes GIGA-42. The missing file is caused by `resetUploadSliceState` running whenever upload related comps are unmounted. Upload related comps gets unmounted because they are wrapped in `AuthenticatedRBACView` which shows a loading skeleton when user or user roles query is fetching. These queries go stale after 5 mins. When they are stale the query is refetched, the loading skeleton is shown, the components are unmounted and the upload reset is triggered.

The fix is to keep the component mounted but hidden.

Also added sentry logging if the file goes missing.

## How to test

1. Go to any upload page
2. Select a file for upload
3. Wait for 5 mins
4. Click proceed
5. Expect the page to show the loading skeleton briefly
6. Fill out the rest of the form
7. Click continue
8.  Expect NOT to encounter the missing file error


