### PR TITLE
chore(backport): [GIGA-42] missing upload file -> production

### DIFF
--- a/ui/src/components/utils/AuthenticatedRBACView.tsx
+++ b/ui/src/components/utils/AuthenticatedRBACView.tsx
@@ -30,13 +30,16 @@ function AuthenticatedRBACView({
 
   return (
     <AuthenticatedView>
-      {isFetching ? (
-        <FullPageLoading />
-      ) : isEnabledAndHasPermissions ? (
-        children
-      ) : (
-        <Forbidden />
-      )}
+      {isFetching && <FullPageLoading />}
+      {!isFetching && !isEnabledAndHasPermissions && <Forbidden />}
+      <div
+        style={{
+          display:
+            isFetching || !isEnabledAndHasPermissions ? "none" : undefined,
+        }}
+      >
+        {children}
+      </div>
     </AuthenticatedView>
   );
 }

--- a/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/metadata.tsx
@@ -19,6 +19,7 @@ import {
   Tag,
 } from "@carbon/react";
 import { zodResolver } from "@hookform/resolvers/zod";
+import * as Sentry from "@sentry/react";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import {
   Link,
@@ -195,7 +196,32 @@ function Metadata() {
 
   const onSubmit: SubmitHandler<MetadataForm> = async data => {
     if (uploadSlice.file === null) {
+      // Log to Sentry with context
+      Sentry.captureException(
+        new Error("File upload attempted with missing file"),
+        {
+          tags: {
+            component: "Metadata",
+            route: "upload-metadata",
+            uploadType,
+            uploadGroup,
+          },
+          extra: {
+            uploadSlice: {
+              hasFile: !!uploadSlice.file,
+              hasColumnMapping: !!uploadSlice.columnMapping,
+              stepIndex: uploadSlice.stepIndex,
+              mode: uploadSlice.mode,
+              source: uploadSlice.source,
+            },
+            formData: data,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      );
+
       setIsNullFile(true);
+      return;
     }
 
     if (Object.keys(errors).length > 0) {


### PR DESCRIPTION

- `chore`: Miscellaneous commits (e.g. modifying `.gitignore`)

Applies GIGA-42 fixes to production.
