### PR TITLE
fix: TECH-9140 file validation

### DIFF
--- a/ui/src/routes/upload/$uploadGroup/$uploadType/index.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { ArrowLeft, ArrowRight } from "@carbon/icons-react";
@@ -21,6 +21,7 @@ import { Select } from "@/components/forms/Select.tsx";
 import {
   AcceptedFileTypes,
   AcceptedUnstructuredFileTypes,
+  MAX_UPLOAD_FILE_SIZE_BYTES,
   MAX_UPLOAD_FILE_SIZE_MB,
   UPLOAD_MODE_OPTIONS,
 } from "@/constants/upload.ts";
@@ -42,7 +43,7 @@ export const Route = createFileRoute("/upload/$uploadGroup/$uploadType/")({
 
 const validStructuredTypes = {
   "text/csv": AcceptedFileTypes.CSV,
-  "application/vnd.ms-excel": AcceptedFileTypes.EXCEL_LEGACY,
+  "application/csv": AcceptedFileTypes.CSV,
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
     AcceptedFileTypes.EXCEL,
 };
@@ -76,6 +77,44 @@ const validUnstructuredTypes = {
     AcceptedUnstructuredFileTypes.DOCX,
 };
 
+type ValidFileTypes = Record<string, string | string[]>;
+
+function getFileExtension(file: File) {
+  const extensionIndex = file.name.lastIndexOf(".");
+  return extensionIndex === -1
+    ? ""
+    : file.name.slice(extensionIndex).toLowerCase();
+}
+
+function getAllowedExtensions(validTypes: ValidFileTypes) {
+  return [...new Set(Object.values(validTypes).flat())];
+}
+
+function getAcceptedFileType(file: File, validTypes: ValidFileTypes) {
+  const fileExtension = getFileExtension(file);
+
+  return getAllowedExtensions(validTypes).find(
+    extension => extension.toLowerCase() === fileExtension,
+  );
+}
+
+function getFileValidationError(file: File, validTypes: ValidFileTypes) {
+  const allowedExtensions = getAllowedExtensions(validTypes);
+  const fileExtension = getFileExtension(file);
+
+  if (!allowedExtensions.includes(fileExtension)) {
+    return `Unsupported file type. Please upload ${allowedExtensions.join(
+      " or ",
+    )} files only.`;
+  }
+
+  if (file.size > MAX_UPLOAD_FILE_SIZE_BYTES) {
+    return `File size exceeds ${MAX_UPLOAD_FILE_SIZE_MB} MB limit`;
+  }
+
+  return "";
+}
+
 export default function Index() {
   const { uploadType, uploadGroup } = Route.useParams();
   const isCoverage = uploadType === "coverage";
@@ -90,11 +129,15 @@ export default function Index() {
     uploadGroup === "other" && uploadType === "unstructured";
   const isStructured = uploadGroup === "other" && uploadType === "structured";
 
-  const validTypes = isUnstructured
-    ? validUnstructuredTypes
-    : isStructured
-    ? validCustomStructuredTypes
-    : validStructuredTypes;
+  const validTypes = useMemo(
+    () =>
+      isUnstructured
+        ? validUnstructuredTypes
+        : isStructured
+        ? validCustomStructuredTypes
+        : validStructuredTypes,
+    [isStructured, isUnstructured],
+  );
   const {
     uploadSlice,
     uploadSliceActions: {
@@ -147,11 +190,23 @@ export default function Index() {
       : !isUnstructured && !isStructured,
   });
 
-  const schema = schemaQuery?.data ?? [];
+  const schemaData = schemaQuery?.data;
+  const schema = useMemo(() => schemaData ?? [], [schemaData]);
 
   useEffect(() => {
-    const { file } = uploadSlice;
     if (schema.length && file) {
+      const validationError = getFileValidationError(file, validTypes);
+      if (validationError) {
+        setFile(null);
+        setTimeStamp(null);
+        setDetectedColumns([]);
+        setColumnMapping({});
+        setParsingError(validationError);
+        setIsParsing(false);
+        return;
+      }
+
+      const acceptedFileType = getAcceptedFileType(file, validTypes);
       const detector = new HeaderDetector({
         file,
         schema,
@@ -159,12 +214,20 @@ export default function Index() {
         setError: setParsingError,
         setColumnMapping,
         setDetectedColumns,
-        type: validTypes[file.type as keyof typeof validTypes],
+        type: acceptedFileType as AcceptedFileTypes,
       });
-      detector.validateFileSize();
+      if (!detector.validateFileSize()) return;
       detector.detect();
     }
-  }, [schema]);
+  }, [
+    file,
+    schema,
+    setColumnMapping,
+    setDetectedColumns,
+    setFile,
+    setTimeStamp,
+    validTypes,
+  ]);
 
   const handleProceedToNextStep = async () => {
     if (isStructured) {
@@ -236,52 +299,32 @@ export default function Index() {
     setParsingError("");
     setIsParsing(true);
 
-    if (isStructured) {
-      // For structured datasets, just validate file size and set the file
-      if (file.size > MAX_UPLOAD_FILE_SIZE_MB * 1024 * 1024) {
-        setParsingError(
-          `File size exceeds ${MAX_UPLOAD_FILE_SIZE_MB} MB limit`,
-        );
-        setIsParsing(false);
-        return;
-      }
-
-      setUploadSliceState({
-        uploadSlice: {
-          ...uploadSlice,
-          fuzzyCorrections: [],
-          fuzzyValidationRequestKey: null,
-          fuzzyValidationResult: null,
-          file: file,
-          timeStamp: new Date(),
-        },
-      });
+    const validationError = getFileValidationError(file, validTypes);
+    if (validationError) {
+      setFile(null);
+      setTimeStamp(null);
+      setDetectedColumns([]);
+      setColumnMapping({});
+      setParsingError(validationError);
       setIsParsing(false);
-    } else {
-      // For other datasets, use HeaderDetector
-      const detector = new HeaderDetector({
-        file,
-        schema,
-        setIsParsing: setIsParsing,
-        setError: setParsingError,
-        setColumnMapping,
-        setDetectedColumns,
-        type: validTypes[file.type as keyof typeof validTypes],
-      });
-      detector.validateFileSize();
-      detector.detect();
-
-      setUploadSliceState({
-        uploadSlice: {
-          ...uploadSlice,
-          fuzzyCorrections: [],
-          fuzzyValidationRequestKey: null,
-          fuzzyValidationResult: null,
-          file: file,
-          timeStamp: new Date(),
-        },
-      });
+      return;
     }
+
+    setUploadSliceState({
+      uploadSlice: {
+        ...uploadSlice,
+        fuzzyCorrections: [],
+        fuzzyValidationRequestKey: null,
+        fuzzyValidationResult: null,
+        file: file,
+        timeStamp: new Date(),
+      },
+    });
+
+    if (isStructured || isUnstructured) {
+      setIsParsing(false);
+    }
+    // For school/coverage/geolocation: useEffect detects when schema is ready
   }
 
   return (
@@ -346,7 +389,7 @@ export default function Index() {
                 />
               ) : (
                 <FileUploaderDropContainer
-                  accept={Object.keys(validTypes)}
+                  accept={getAllowedExtensions(validTypes)}
                   name="file"
                   labelText="Click or drag a file to upload"
                   onAddFiles={(_, { addedFiles }: { addedFiles: File[] }) =>

--- a/ui/src/routes/upload/$uploadGroup/$uploadType/index.tsx
+++ b/ui/src/routes/upload/$uploadGroup/$uploadType/index.tsx
@@ -44,6 +44,8 @@ export const Route = createFileRoute("/upload/$uploadGroup/$uploadType/")({
 const validStructuredTypes = {
   "text/csv": AcceptedFileTypes.CSV,
   "application/csv": AcceptedFileTypes.CSV,
+  "application/vnd.ms-excel": AcceptedFileTypes.EXCEL_LEGACY,
+  "application/x-ole-storage": AcceptedFileTypes.EXCEL_LEGACY,
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
     AcceptedFileTypes.EXCEL,
 };


### PR DESCRIPTION
TECH-9140 file type validation



## Summary

This PR adds client-side file validation before storing uploaded files in the upload flow state.

For uploads that proceed to column mapping, only .csv and .xlsx files are now accepted. Unsupported files such as .doc, .docx, .png, or .pdf are rejected immediately with a clear error message, preventing users from advancing to the mapping step with invalid files.

Unstructured uploads continue to allow their broader set of image and document formats, and no longer run header detection logic that only applies to structured/mapping uploads.
