### PR TITLE
feat: add approval_status to file_uploads table

### DIFF
--- a/ui/src/components/check-file-uploads/ColumnSelectorModal.tsx
+++ b/ui/src/components/check-file-uploads/ColumnSelectorModal.tsx
@@ -19,6 +19,7 @@ export const ALL_COLUMN_CONFIGS: ColumnConfig[] = [
   { key: "rows_passed", label: "Records Passed" },
   { key: "rows_failed", label: "Records Rejected" },
   { key: "data_owner", label: "Data Owner" },
+  { key: "approval_status", label: "Approval status" },
   { key: "status", label: "DQ status" },
 ];
 

--- a/ui/src/components/check-file-uploads/UploadsTable.tsx
+++ b/ui/src/components/check-file-uploads/UploadsTable.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useMemo } from "react";
+import { ComponentProps, ReactElement, useMemo } from "react";
 
 import {
   Button,
@@ -77,6 +77,10 @@ const ALL_COLUMNS: DataTableHeader[] = [
     header: "Data owner",
   },
   {
+    key: "approval_status",
+    header: "Approval status",
+  },
+  {
     key: "status",
     header: "DQ check status",
   },
@@ -85,6 +89,15 @@ const ALL_COLUMNS: DataTableHeader[] = [
     header: "",
   },
 ];
+
+const ApprovalStatusTagMapping: Record<
+  NonNullable<UploadResponse["approval_status"]>,
+  ComponentProps<typeof Tag>["type"]
+> = {
+  PENDING: "gray",
+  APPROVED: "green",
+  REJECTED: "red",
+};
 
 type TableUpload = Record<
   keyof UploadResponse,
@@ -202,6 +215,16 @@ function UploadsTable({
           >
             {statusText}
           </Tag>
+        ),
+        approval_status: upload.approval_status ? (
+          <Tag
+            type={ApprovalStatusTagMapping[upload.approval_status]}
+            className="capitalize"
+          >
+            {upload.approval_status.toLowerCase()}
+          </Tag>
+        ) : (
+          "—"
         ),
         actions: !isUnstructured && (
           <Button


### PR DESCRIPTION
add approval_status to file_uploads table

## What type of PR is this?

- `build`: Commits that affect build components like build tool, dependencies, project
  version
- `chore`: Miscellaneous commits (e.g. modifying `.gitignore`)
- `ci`: Commits are special `build` commits that affect the CI/CD pipeline
- `docs`: Commits that affect documentation only
- `feat`: Commits that add a new feature
- `fix`: Commits that fix a bug
- `perf`: Commits are special `refactor` commits that improve performance
- `refactor`: Commits that rewrite/restructure your code, however does not change any
  behaviour
- `revert`: Commits that revert another commit/PR, usually can be autogenerated on
  GitHub or using `git revert`
- `style`: Commits are special `refactor` commits that edit the code to comply with a
  code style, linter, or formatter
- `test`: Commits that add missing tests or correcting existing tests

## Summary

What does this PR do

## How to test

1. Instructions on how to test
2. Specify which files to review
3. etc.

## Link to Jira/Asana/Airtable task (if applicable)

_placeholder_

## Wireframe screenshot/screencap (if applicable)

_placeholder_

## Implementation screenshot/screencap (if applicable)

_placeholder_
