### PR TITLE
fix: fix dq check critical checks tab

### DIFF
--- a/ui/src/utils/dq-summary.ts
+++ b/ui/src/utils/dq-summary.ts
@@ -3,7 +3,6 @@ import { Check, DataQualityCheckSummary } from "@/types/upload";
 const DQ_SUMMARY_META_KEYS = new Set([
   "summary",
   "critical_error_check",
-  "critical_checks",
   "valueMaps",
 ]);
 


### PR DESCRIPTION
Re-add critical checks tab that was removed on a old commit
