### PR TITLE
fix: DQR PDF layout, footer clearance, unified Mappings table

### DIFF
--- a/email/src/i18n/en.json
+++ b/email/src/i18n/en.json
@@ -51,6 +51,8 @@
     }
   },
   "excelSheet": "Excel Sheet",
+  "excelSheetRejected": "Rejected_",
+  "excelSheetWarning": "Warning_",
   "ingestionId": "Ingestion ID",
   "lowPrecision": "Low precision coordinates (less than 5 digits)",
   "mappings": "Mappings",

--- a/email/src/i18n/es.json
+++ b/email/src/i18n/es.json
@@ -29,6 +29,8 @@
     }
   },
   "excelSheet": "Hoja de Excel",
+  "excelSheetRejected": "Rechazadas_",
+  "excelSheetWarning": "Advertencia_",
   "ingestionId": "ID de Ingesta",
   "lowPrecision": "Coordenadas de baja precisión (menos de 5 dígitos)",
   "mappings": "Mapas",

--- a/email/src/i18n/fr.json
+++ b/email/src/i18n/fr.json
@@ -29,6 +29,8 @@
     }
   },
   "excelSheet": "Fichier Excel",
+  "excelSheetRejected": "Rejetées_",
+  "excelSheetWarning": "Avertissement_",
   "ingestionId": "ID d'intégration",
   "lowPrecision": "Coordonnées basse précision (< 5 chiffres)",
   "mappings": "Correspondances",

--- a/email/src/lib/pdf-generator.ts
+++ b/email/src/lib/pdf-generator.ts
@@ -11,7 +11,7 @@ import {
   rgb,
   StandardFonts,
 } from "pdf-lib";
-import puppeteer, { type Browser } from "puppeteer-core";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
 
 import { loadPdfLogoDataUri } from "./blob-assets";
 import {
@@ -854,23 +854,42 @@ const COLLECT_ROW_HEIGHTS = `(function () {
 })()`;
 
 
+async function loadForPrint(page: Page, html: string): Promise<void> {
+  await page.emulateMediaType("print");
+  await page.setContent(html, { waitUntil: "networkidle0" });
+  // Resolve to a primitive: FontFaceSet itself is not serialisable.
+  await page.evaluate("document.fonts.ready.then(function () { return true; })");
+}
+
+/**
+ * Real row heights, measured by rendering once. A second `setContent` on a page
+ * that already has content never reaches `networkidle0`, so this uses its own.
+ */
+async function measureRowHeights(
+  browser: Browser,
+  html: string
+): Promise<RowHeights> {
+  const page = await browser.newPage();
+  try {
+    await loadForPrint(page, html);
+    return (await page.evaluate(COLLECT_ROW_HEIGHTS)) as RowHeights;
+  } finally {
+    await page.close();
+  }
+}
+
 export async function generateDataQualityReportPDF(
   data: PDFReportData
 ): Promise<Buffer> {
   const browser = await getBrowser();
+
+  // Pass 1 lays out with estimated row heights; pass 2 repaginates with the
+  // heights the browser actually produced, so wrapped labels never overflow.
+  const measured = await measureRowHeights(browser, await renderHtml(data));
+
   const page = await browser.newPage();
   try {
-    await page.emulateMediaType("print");
-
-    // Pass 1 lays out with estimated row heights; pass 2 repaginates with the
-    // heights the browser actually produced, so wrapped labels never overflow.
-    await page.setContent(await renderHtml(data), { waitUntil: "networkidle0" });
-    await page.evaluate("document.fonts.ready");
-    const measured = (await page.evaluate(COLLECT_ROW_HEIGHTS)) as RowHeights;
-
-    await page.setContent(await renderHtml(data, measured), {
-      waitUntil: "networkidle0",
-    });
+    await loadForPrint(page, await renderHtml(data, measured));
 
     const pdf = await page.pdf({
       format: "A4",

--- a/email/src/lib/pdf-generator.ts
+++ b/email/src/lib/pdf-generator.ts
@@ -125,8 +125,16 @@ function makeNumberFormatters(tag: string) {
     useGrouping: false,
   });
 
+  // "always" keeps the separator on 4-digit numbers, which es-ES drops by
+  // default — otherwise 1127 and 95.488 sit in the same column. The option is
+  // ES2023; TypeScript 5.3 still types it as boolean, hence the cast.
+  const integer = new Intl.NumberFormat(tag, {
+    useGrouping: "always",
+    maximumFractionDigits: 0,
+  } as unknown as Intl.NumberFormatOptions);
+
   const fmt = (n: number): string =>
-    Number.isFinite(n) ? Math.round(n).toLocaleString(tag) : "0";
+    Number.isFinite(n) ? integer.format(Math.round(n)) : "0";
 
   const pctOf = (part: number, total: number): string => {
     if (total <= 0) return "0%";
@@ -136,7 +144,24 @@ function makeNumberFormatters(tag: string) {
   const pctParen = (part: number, total: number): string =>
     `(${pctOf(part, total)})`;
 
-  return { fmt, pctOf, pctParen };
+  const pctValue = (n: number): string => `${percent.format(n)}%`;
+
+  return { fmt, pctOf, pctParen, pctValue };
+}
+
+/**
+ * valueMaps reach us pre-formatted in en-US ("95,488", "39.0%"). Re-format them
+ * so separators match the rest of the report; leave anything unparseable alone.
+ */
+function reformatNumeric(
+  raw: string | undefined,
+  format: (n: number) => string
+): string {
+  const text = String(raw ?? "").trim();
+  const bare = text.replace(/%/g, "").replace(/,/g, "").trim();
+  if (bare === "") return text;
+  const n = Number(bare);
+  return Number.isFinite(n) ? format(n) : text;
 }
 
 const emDash = "—";
@@ -467,7 +492,9 @@ async function buildContext(data: PDFReportData, measured?: RowHeights) {
     ep === "Health Centers" ? "healthCenters" : "schools";
   const tr = (key: string) => t(language, key);
   const te = (key: string) => entityText(language, entityKey, key);
-  const { fmt, pctParen } = makeNumberFormatters(LOCALE_TAG[language]);
+  const { fmt, pctParen, pctValue } = makeNumberFormatters(
+    LOCALE_TAG[language]
+  );
 
   const uploaded = Number(summary.rows ?? 0) || 0;
   const approved = Number(
@@ -662,7 +689,12 @@ async function buildContext(data: PDFReportData, measured?: RowHeights) {
   // `mk` keys survive into the markup so a render pass can report real heights.
   let mapKey = 0;
   const keyMaps = (rows: ValueMapRow[]): KeyedMapRow[] =>
-    rows.map((row) => ({ ...row, mk: `m${mapKey++}` }));
+    rows.map((row) => ({
+      ...row,
+      count: reformatNumeric(row.count, fmt),
+      pct: reformatNumeric(row.pct, pctValue),
+      mk: `m${mapKey++}`,
+    }));
   const educationMaps = keyMaps(valueMaps.education ?? []);
   const electricityMaps = keyMaps(valueMaps.electricity ?? []);
   const connectivityAll = keyMaps(valueMaps.connectivity ?? []);
@@ -776,6 +808,8 @@ async function buildContext(data: PDFReportData, measured?: RowHeights) {
       rejected: tr("rejected"),
       warnings: tr("warnings"),
       excelSheet: tr("excelSheet"),
+      excelSheetWarning: tr("excelSheetWarning"),
+      excelSheetRejected: tr("excelSheetRejected"),
       approvedWithWarnings: tr("approvedWithWarnings"),
       mappings: tr("mappings"),
       mappingsNote: tr("mappingsNote"),

--- a/email/src/lib/pdf-generator.ts
+++ b/email/src/lib/pdf-generator.ts
@@ -192,37 +192,81 @@ const PAGE_CONTENT_BOTTOM = 790;
 /** Keep tables clear of the page footer band. */
 const PAGE_CONTENT_SAFE_BOTTOM = PAGE_CONTENT_BOTTOM - 12;
 const PAGE2_MAPS_TABLE_START = 258;
+const PAGE2_WARNINGS_TOP = 69;
 const SECTION_GAP = 16;
-const MAP_TABLE_HEAD = 28;
-const MAP_ROW_HEIGHT = 24;
-const META_TABLE_HEAD = 36;
-const META_ROW_HEIGHT = 24;
 
-/** Map rows with long source labels wrap to two lines in the 160pt column. */
-function estimateMapRowHeight(row: ValueMapRow): number {
-  const len = row.src?.length ?? 0;
-  if (len > 35) return 40;
-  if (len > 20) return 32;
-  return MAP_ROW_HEIGHT;
+// Mirrors the .tbl / .thead / .trow box model in dq-report.html. 1px = 0.75pt.
+const ROW_LINE = 16;
+const ROW_PAD_Y = 3;
+const ROW_BORDER = 0.375;
+const TBL_BORDERS = 1.5;
+const HEAD_COMPACT = 22.375;
+const HEAD_FULL = 24;
+const MAP_SRC_COL = 160;
+const MAP_DST_COL = 174;
+const META_VALUE_COL = 265;
+const TABLE_LABEL_COL = 362;
+const CHAR_WIDTH = 5;
+
+function rowHeight(lines: number): number {
+  return ROW_PAD_Y * 2 + lines * ROW_LINE + ROW_BORDER;
 }
 
-function mapTableHeight(rowCount: number, rows?: ValueMapRow[]): number {
-  if (rowCount <= 0) return 0;
-  if (rows && rows.length > 0) {
-    const body = rows
-      .slice(0, rowCount)
-      .reduce((sum, row) => sum + estimateMapRowHeight(row), 0);
-    return MAP_TABLE_HEAD + body;
-  }
-  return MAP_TABLE_HEAD + rowCount * MAP_ROW_HEIGHT;
+function lineCount(text: string | undefined, columnWidth: number): number {
+  const perLine = Math.max(1, Math.floor(columnWidth / CHAR_WIDTH));
+  return Math.max(1, Math.ceil((text?.length ?? 0) / perLine));
 }
 
-function maxMapRowsThatFit(rows: ValueMapRow[], maxHeight: number): number {
-  if (maxHeight < MAP_TABLE_HEAD || rows.length === 0) return 0;
-  let used = MAP_TABLE_HEAD;
+/**
+ * Row heights measured in the browser on a first render pass, keyed by `mk`.
+ * Absent on the first pass, where the char-width estimate stands in.
+ */
+export type RowHeights = Record<string, number>;
+
+type KeyedMapRow = ValueMapRow & { mk: string };
+type KeyedMetaRow = { label: string; value: string; mk: string };
+
+function mapRowHeight(row: KeyedMapRow, measured?: RowHeights): number {
+  const m = measured?.[row.mk];
+  if (m !== undefined) return m;
+  return rowHeight(
+    Math.max(lineCount(row.src, MAP_SRC_COL), lineCount(row.dst, MAP_DST_COL))
+  );
+}
+
+function metaRowHeight(row: KeyedMetaRow, measured?: RowHeights): number {
+  const m = measured?.[row.mk];
+  if (m !== undefined) return m;
+  return rowHeight(lineCount(row.value, META_VALUE_COL));
+}
+
+type MapGroup = { title: string; rows: KeyedMapRow[] };
+
+function mapsTableHeight(groups: MapGroup[], measured?: RowHeights): number {
+  if (groups.length === 0) return 0;
+  return (
+    TBL_BORDERS +
+    groups.reduce(
+      (sum, group) =>
+        sum +
+        HEAD_COMPACT +
+        group.rows.reduce((rows, row) => rows + mapRowHeight(row, measured), 0),
+      0
+    )
+  );
+}
+
+/** `maxHeight` budgets one group: its sub-header plus rows, table borders excluded. */
+function maxMapRowsThatFit(
+  rows: KeyedMapRow[],
+  maxHeight: number,
+  measured?: RowHeights
+): number {
+  let used = HEAD_COMPACT;
+  if (maxHeight < used || rows.length === 0) return 0;
   let count = 0;
   for (const row of rows) {
-    const rowH = estimateMapRowHeight(row);
+    const rowH = mapRowHeight(row, measured);
     if (used + rowH > maxHeight) break;
     used += rowH;
     count++;
@@ -231,44 +275,47 @@ function maxMapRowsThatFit(rows: ValueMapRow[], maxHeight: number): number {
 }
 
 function splitConnectivityForPage2(
-  rows: ValueMapRow[],
-  connectivityTop: number
-): { page2: ValueMapRow[]; overflow: ValueMapRow[] } {
-  const avail = PAGE_CONTENT_SAFE_BOTTOM - connectivityTop;
-  const maxRows = maxMapRowsThatFit(rows, avail);
+  rows: KeyedMapRow[],
+  connectivityTop: number,
+  measured?: RowHeights
+): { page2: KeyedMapRow[]; overflow: KeyedMapRow[] } {
+  const avail = PAGE_CONTENT_SAFE_BOTTOM - connectivityTop - TBL_BORDERS;
+  const maxRows = maxMapRowsThatFit(rows, avail, measured);
   if (maxRows <= 0) return { page2: [], overflow: rows };
   if (rows.length <= maxRows) return { page2: rows, overflow: [] };
   return { page2: rows.slice(0, maxRows), overflow: rows.slice(maxRows) };
 }
 
 function metadataTableHeight(
-  rows: Array<{ label: string; value: string }>
+  rows: KeyedMetaRow[],
+  measured?: RowHeights
 ): number {
-  const body = rows.reduce((sum, row) => {
-    const len = row.value.length;
-    if (len > 120) return sum + 48;
-    if (len > 60) return sum + 36;
-    return sum + META_ROW_HEIGHT;
-  }, 0);
-  return META_TABLE_HEAD + body;
+  const body = rows.reduce(
+    (sum, row) => sum + metaRowHeight(row, measured),
+    0
+  );
+  return TBL_BORDERS + HEAD_FULL + body;
 }
 
 type TailPageLayout = {
-  connectivity: ValueMapRow[];
+  connectivity: KeyedMapRow[];
   includeMetadata: boolean;
 };
 
 /** Paginate connectivity overflow + metadata across pages 3+ without splitting tables mid-page. */
 function layoutTailPages(
-  connectivityOverflow: ValueMapRow[],
-  metadataRows: Array<{ label: string; value: string }>
+  connectivityOverflow: KeyedMapRow[],
+  metadataRows: KeyedMetaRow[],
+  metadataOnPage2: boolean,
+  measured?: RowHeights
 ): TailPageLayout[] {
-  const metaH = metadataTableHeight(metadataRows);
-  const needMeta = metadataRows.length > 0;
+  const metaH = metadataTableHeight(metadataRows, measured);
+  const needMeta = !metadataOnPage2 && metadataRows.length > 0;
   const pages: TailPageLayout[] = [];
   let connIdx = 0;
 
-  const pageAvail = () => PAGE_CONTENT_SAFE_BOTTOM - PAGE_CONTENT_TOP;
+  const pageAvail = () =>
+    PAGE_CONTENT_SAFE_BOTTOM - PAGE_CONTENT_TOP - TBL_BORDERS;
   const metaPlaced = () => pages.some((p) => p.includeMetadata);
 
   while (
@@ -282,7 +329,7 @@ function layoutTailPages(
 
     if (metaStillNeeded && remaining > 0) {
       const connBudget = pageAvail() - SECTION_GAP - metaH;
-      const take = maxMapRowsThatFit(remainingSlice, connBudget);
+      const take = maxMapRowsThatFit(remainingSlice, connBudget, measured);
       if (take > 0) {
         pages.push({
           connectivity: connectivityOverflow.slice(connIdx, connIdx + take),
@@ -294,7 +341,7 @@ function layoutTailPages(
     }
 
     if (remaining > 0) {
-      const take = maxMapRowsThatFit(remainingSlice, pageAvail());
+      const take = maxMapRowsThatFit(remainingSlice, pageAvail(), measured);
       if (take <= 0) break;
       pages.push({
         connectivity: connectivityOverflow.slice(connIdx, connIdx + take),
@@ -316,27 +363,31 @@ function layoutTailPages(
 }
 
 function buildPostPage2Sections(
-  tailLayouts: TailPageLayout[]
+  tailLayouts: TailPageLayout[],
+  connectivityTitle: string,
+  measured?: RowHeights
 ): Array<{
-  connectivity: ValueMapRow[];
+  mapsGroups: MapGroup[];
   includeMetadata: boolean;
-  connectivityTop: number;
+  mapsTableTop: number;
   metadataTop: number;
   pageNum: string;
 }> {
   let pageNum = 3;
   return tailLayouts.map((layout) => {
-    const connectivityTop = PAGE_CONTENT_TOP;
+    const mapsGroups: MapGroup[] =
+      layout.connectivity.length > 0
+        ? [{ title: connectivityTitle, rows: layout.connectivity }]
+        : [];
     const metadataTop = layout.includeMetadata
-      ? layout.connectivity.length > 0
-        ? connectivityTop +
-          mapTableHeight(layout.connectivity.length, layout.connectivity) +
-          SECTION_GAP
+      ? mapsGroups.length > 0
+        ? PAGE_CONTENT_TOP + mapsTableHeight(mapsGroups, measured) + SECTION_GAP
         : PAGE_CONTENT_TOP
       : 0;
     return {
-      ...layout,
-      connectivityTop,
+      mapsGroups,
+      includeMetadata: layout.includeMetadata,
+      mapsTableTop: PAGE_CONTENT_TOP,
       metadataTop,
       pageNum: String(pageNum++).padStart(2, "0"),
     };
@@ -382,7 +433,7 @@ async function getBrowser(): Promise<Browser> {
   return cachedBrowser;
 }
 
-async function buildContext(data: PDFReportData) {
+async function buildContext(data: PDFReportData, measured?: RowHeights) {
   const dq = (data.dataQualityCheck ?? {}) as Record<string, unknown>;
   const summary =
     (dq["summary"] as {
@@ -608,9 +659,13 @@ async function buildContext(data: PDFReportData) {
   ];
 
   const valueMaps = data.valueMaps ?? {};
-  const educationMaps = valueMaps.education ?? [];
-  const electricityMaps = valueMaps.electricity ?? [];
-  const connectivityAll = valueMaps.connectivity ?? [];
+  // `mk` keys survive into the markup so a render pass can report real heights.
+  let mapKey = 0;
+  const keyMaps = (rows: ValueMapRow[]): KeyedMapRow[] =>
+    rows.map((row) => ({ ...row, mk: `m${mapKey++}` }));
+  const educationMaps = keyMaps(valueMaps.education ?? []);
+  const electricityMaps = keyMaps(valueMaps.electricity ?? []);
+  const connectivityAll = keyMaps(valueMaps.connectivity ?? []);
 
   const hasEducationMaps = educationMaps.length > 0;
   const hasElectricityMaps = electricityMaps.length > 0;
@@ -619,7 +674,11 @@ async function buildContext(data: PDFReportData) {
     hasEducationMaps || hasElectricityMaps || hasConnectivityMaps;
 
   const metaRaw = data.uploadMetadata ?? {};
-  const metadataRows = buildMetadataRows(metaRaw, language, entityKey);
+  const metadataRows: KeyedMetaRow[] = buildMetadataRows(
+    metaRaw,
+    language,
+    entityKey
+  ).map((row, i) => ({ ...row, mk: `d${i}` }));
 
   // Dagster reports these inside dq-summary (snake_case); top-level props win.
   const schoolsCreatedRaw = data.schoolsCreated ?? summary.schools_created;
@@ -633,47 +692,70 @@ async function buildContext(data: PDFReportData) {
     schoolsUpdatedRaw !== undefined &&
     String(schoolsUpdatedRaw).trim() !== "";
 
-  let page2NextTop = PAGE2_MAPS_TABLE_START;
   const mapsSectionTop = 193;
   const mapsNoteTop = 213;
-  let educationMapsTop = 0;
-  let electricityMapsTop = 0;
-  let connectivityMapsTop = 0;
-  let connectivityPage2: ValueMapRow[] = [];
-  let connectivityOverflow: ValueMapRow[] = connectivityAll;
+  const mapsTableTop = PAGE2_MAPS_TABLE_START;
+  const mapsGroups: MapGroup[] = [];
+  let connectivityOverflow: KeyedMapRow[] = connectivityAll;
 
   if (hasMapsSection) {
     if (educationMaps.length > 0) {
-      educationMapsTop = page2NextTop;
-      page2NextTop += mapTableHeight(educationMaps.length, educationMaps);
+      mapsGroups.push({ title: tr("educationLevel"), rows: educationMaps });
     }
     if (electricityMaps.length > 0) {
-      electricityMapsTop = page2NextTop;
-      page2NextTop += mapTableHeight(electricityMaps.length, electricityMaps);
+      mapsGroups.push({ title: tr("electricity"), rows: electricityMaps });
     }
     if (connectivityAll.length > 0) {
-      connectivityMapsTop = page2NextTop;
+      const connectivityTop =
+        mapsTableTop + mapsTableHeight(mapsGroups, measured);
       const split = splitConnectivityForPage2(
         connectivityAll,
-        connectivityMapsTop
+        connectivityTop,
+        measured
       );
-      connectivityPage2 = split.page2;
       connectivityOverflow = split.overflow;
-      if (connectivityPage2.length > 0) {
-        page2NextTop += mapTableHeight(
-          connectivityPage2.length,
-          connectivityPage2
-        );
+      if (split.page2.length > 0) {
+        mapsGroups.push({ title: tr("connectivity"), rows: split.page2 });
       }
     }
   }
+
+  const page2WarningsBottom =
+    PAGE2_WARNINGS_TOP +
+    TBL_BORDERS +
+    HEAD_FULL +
+    warningsPage2Rows.reduce(
+      (sum, row) => sum + rowHeight(lineCount(row.label, TABLE_LABEL_COL)),
+      0
+    );
+
+  // Page 2 keeps Metadata only when the whole table fits below the mappings.
+  const page2ContentBottom =
+    mapsGroups.length > 0
+      ? mapsTableTop + mapsTableHeight(mapsGroups, measured)
+      : page2WarningsBottom;
+  const metadataPage2Top = page2ContentBottom + SECTION_GAP;
+  const includeMetadataPage2 =
+    connectivityOverflow.length === 0 &&
+    metadataRows.length > 0 &&
+    metadataPage2Top + metadataTableHeight(metadataRows, measured) <=
+      PAGE_CONTENT_SAFE_BOTTOM;
   const parsedUploadDate = new Date(data.uploadDate);
   const localizedUploadDate = Number.isNaN(parsedUploadDate.getTime())
     ? data.uploadDate
     : formatDateForPDF(parsedUploadDate, language);
 
-  const tailLayouts = layoutTailPages(connectivityOverflow, metadataRows);
-  const postPage2Pages = buildPostPage2Sections(tailLayouts);
+  const tailLayouts = layoutTailPages(
+    connectivityOverflow,
+    metadataRows,
+    includeMetadataPage2,
+    measured
+  );
+  const postPage2Pages = buildPostPage2Sections(
+    tailLayouts,
+    tr("connectivity"),
+    measured
+  );
 
   const pageCount = 2 + postPage2Pages.length;
 
@@ -734,19 +816,14 @@ async function buildContext(data: PDFReportData) {
     rejectedSections,
     warningsPage1Sections,
     warningsPage2Rows,
-    educationMaps,
-    electricityMaps,
-    connectivityPage2,
+    mapsGroups,
     postPage2Pages,
-    hasEducationMaps,
-    hasElectricityMaps,
-    hasConnectivityMaps,
     hasMapsSection,
     mapsSectionTop,
     mapsNoteTop,
-    educationMapsTop,
-    electricityMapsTop,
-    connectivityMapsTop,
+    mapsTableTop,
+    includeMetadataPage2,
+    metadataPage2Top,
     metadataRows,
     hasMetadata: metadataRows.some((r) => r.value !== emDash),
     pageCount,
@@ -757,22 +834,43 @@ async function buildContext(data: PDFReportData) {
   };
 }
 
-export async function renderHtml(data: PDFReportData): Promise<string> {
+export async function renderHtml(
+  data: PDFReportData,
+  measured?: RowHeights
+): Promise<string> {
   const template = loadTemplate();
-  return template(await buildContext(data));
+  return template(await buildContext(data, measured));
 }
+
+/** Real rendered heights of every keyed table row, in points. */
+const COLLECT_ROW_HEIGHTS = `(function () {
+  var out = {};
+  var nodes = document.querySelectorAll("[data-mk]");
+  for (var i = 0; i < nodes.length; i++) {
+    out[nodes[i].getAttribute("data-mk")] =
+      nodes[i].getBoundingClientRect().height * 72 / 96;
+  }
+  return out;
+})()`;
 
 
 export async function generateDataQualityReportPDF(
   data: PDFReportData
 ): Promise<Buffer> {
-  const html = await renderHtml(data);
-
   const browser = await getBrowser();
   const page = await browser.newPage();
   try {
-    await page.setContent(html, { waitUntil: "networkidle0" });
     await page.emulateMediaType("print");
+
+    // Pass 1 lays out with estimated row heights; pass 2 repaginates with the
+    // heights the browser actually produced, so wrapped labels never overflow.
+    await page.setContent(await renderHtml(data), { waitUntil: "networkidle0" });
+    await page.evaluate("document.fonts.ready");
+    const measured = (await page.evaluate(COLLECT_ROW_HEIGHTS)) as RowHeights;
+
+    await page.setContent(await renderHtml(data, measured), {
+      waitUntil: "networkidle0",
+    });
 
     const pdf = await page.pdf({
       format: "A4",

--- a/email/src/templates/dq-report.html
+++ b/email/src/templates/dq-report.html
@@ -173,14 +173,14 @@
         <div class="statline"><span class="num amber">{{totals.approvedWithWarnings}}</span><span class="pct">{{totals.warningsPctParen}}</span></div>
         <div class="statlabel">{{t.approvedWithWarnings}}</div>
       </div>
-      <div class="excel">{{t.excelSheet}}: <span class="lnk">Warning_</span></div>
+      <div class="excel">{{t.excelSheet}}: <span class="lnk">{{t.excelSheetWarning}}</span></div>
     </div>
     <div class="statcell span2">
       <div>
         <div class="statline"><span class="num red">{{totals.rejected}}</span><span class="pct">{{totals.rejectedPctParen}}</span></div>
         <div class="statlabel">{{t.entityRejected}}</div>
       </div>
-      <div class="excel">{{t.excelSheet}}: <span class="lnk">Rejected_</span></div>
+      <div class="excel">{{t.excelSheet}}: <span class="lnk">{{t.excelSheetRejected}}</span></div>
     </div>
     <div class="statarrow">
       <svg viewBox="0 0 26 12" fill="none"><path d="M0 6h23M19 2l4 4-4 4" stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/email/src/templates/dq-report.html
+++ b/email/src/templates/dq-report.html
@@ -31,9 +31,12 @@
     border: 1px solid #cdcdcd; padding: 4pt 8pt;
     font-weight: 600; font-size: 10pt; line-height: 16pt;
   }
+  /* Reserved band: content never crowds the footer line. */
   .footer {
-    position: absolute; left: 20pt; right: 19pt; top: 806pt;
-    display: flex; align-items: center; justify-content: flex-end;
+    position: absolute; left: 0; right: 0; top: 798pt; bottom: 0;
+    padding: 8pt 19pt 0 20pt;
+    background: #fff;
+    display: flex; align-items: flex-start; justify-content: flex-end;
     gap: 16pt;
     font-weight: 500; font-size: 10pt; line-height: 16pt;
     letter-spacing: -0.1pt; white-space: nowrap;
@@ -52,7 +55,8 @@
     padding: 0 8pt; min-height: 24pt;
     font-weight: 600; font-size: 10pt; line-height: 16pt;
   }
-  .thead.compact { padding: 4pt 8pt; min-height: 0; }
+  .thead.compact { padding: 3pt 8pt; min-height: 0; }
+  .tbl .thead.compact:not(:first-child) { border-top: 0.5px solid #e9e9e9; }
   .thead .title { flex: 1; }
   .thead .ico { display: flex; align-items: center; gap: 4pt; flex: 1; }
   .thead .ico .title { flex: 0 1 auto; font-weight: 700; }
@@ -60,13 +64,13 @@
   .tsub {
     background: rgba(245,245,245,0.5);
     display: flex; align-items: center;
-    padding: 0 8pt; min-height: 24pt;
+    padding: 0 8pt; min-height: 22pt;
     font-weight: 600; font-size: 10pt; line-height: 16pt;
   }
   .trow {
     border-top: 0.5px solid #e9e9e9;
     display: flex; align-items: center; gap: 8pt;
-    padding: 4pt 8pt;
+    padding: 3pt 8pt;
     font-size: 10pt; line-height: 16pt;
     letter-spacing: -0.1pt;
   }
@@ -200,7 +204,7 @@
     {{/each}}
   </div>
 
-  <div class="tbl" style="top:586pt;">
+  <div class="tbl" style="top:568pt;">
     <div class="thead">
       <div class="ico">
         <svg class="wico" viewBox="0 0 12 12" aria-hidden="true"><path d="M6 0.6 11.6 11H0.4L6 0.6Z" fill="#ffae00"/><rect x="5.3" y="4" width="1.4" height="3.6" rx="0.7" fill="#000"/><circle cx="6" cy="9.2" r="0.8" fill="#000"/></svg>
@@ -247,56 +251,31 @@
   <div class="section-note" style="top:{{mapsNoteTop}}pt;">{{t.mappingsNote}}</div>
   {{/if}}
 
-  {{#if hasEducationMaps}}
-  <div class="tbl" style="top:{{educationMapsTop}}pt;">
+  {{#if mapsGroups.length}}
+  <div class="tbl" style="top:{{mapsTableTop}}pt;">
+    {{#each mapsGroups}}
     <div class="thead compact">
-      <span class="title">{{t.educationLevel}}</span>
+      <span class="title">{{title}}</span>
       <span class="col-num">#</span>
       <span class="col-num">%</span>
     </div>
-    {{#each educationMaps}}
-    <div class="trow map">
+    {{#each rows}}
+    <div class="trow map" data-mk="{{mk}}">
       <span class="src">{{src}}</span>
       <span class="arrow"><svg viewBox="0 0 12 12" fill="none"><path d="M1 6h8.5M7 3l3 3-3 3" stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="dst">{{dst}}</span>
       <span class="val">{{count}}</span><span class="val">{{pct}}</span>
     </div>
     {{/each}}
-  </div>
-  {{/if}}
-
-  {{#if hasElectricityMaps}}
-  <div class="tbl" style="top:{{electricityMapsTop}}pt;">
-    <div class="thead compact">
-      <span class="title">{{t.electricity}}</span>
-      <span class="col-num">#</span>
-      <span class="col-num">%</span>
-    </div>
-    {{#each electricityMaps}}
-    <div class="trow map">
-      <span class="src">{{src}}</span>
-      <span class="arrow"><svg viewBox="0 0 12 12" fill="none"><path d="M1 6h8.5M7 3l3 3-3 3" stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <span class="dst">{{dst}}</span>
-      <span class="val">{{count}}</span><span class="val">{{pct}}</span>
-    </div>
     {{/each}}
   </div>
   {{/if}}
 
-  {{#if connectivityPage2.length}}
-  <div class="tbl" style="top:{{connectivityMapsTop}}pt;">
-    <div class="thead compact">
-      <span class="title">{{t.connectivity}}</span>
-      <span class="col-num">#</span>
-      <span class="col-num">%</span>
-    </div>
-    {{#each connectivityPage2}}
-    <div class="trow map">
-      <span class="src">{{src}}</span>
-      <span class="arrow"><svg viewBox="0 0 12 12" fill="none"><path d="M1 6h8.5M7 3l3 3-3 3" stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
-      <span class="dst">{{dst}}</span>
-      <span class="val">{{count}}</span><span class="val">{{pct}}</span>
-    </div>
+  {{#if includeMetadataPage2}}
+  <div class="tbl" style="top:{{metadataPage2Top}}pt;">
+    <div class="thead"><span class="title">{{t.metadata}}</span></div>
+    {{#each metadataRows}}
+    <div class="trow meta" data-mk="{{mk}}"><span class="label">{{label}}</span><span class="value">{{value}}</span></div>
     {{/each}}
   </div>
   {{/if}}
@@ -313,20 +292,22 @@
   <div class="logo"><img src="{{../logoDataUri}}" alt="GIGA · UNICEF · ITU" /></div>
   <div class="badge">{{../t.entityPlural}}</div>
 
-  {{#if connectivity.length}}
-  <div class="tbl" style="top:{{connectivityTop}}pt;">
+  {{#if mapsGroups.length}}
+  <div class="tbl" style="top:{{mapsTableTop}}pt;">
+    {{#each mapsGroups}}
     <div class="thead compact">
-      <span class="title">{{../t.connectivity}}</span>
+      <span class="title">{{title}}</span>
       <span class="col-num">#</span>
       <span class="col-num">%</span>
     </div>
-    {{#each connectivity}}
-    <div class="trow map">
+    {{#each rows}}
+    <div class="trow map" data-mk="{{mk}}">
       <span class="src">{{src}}</span>
       <span class="arrow"><svg viewBox="0 0 12 12" fill="none"><path d="M1 6h8.5M7 3l3 3-3 3" stroke="#000" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
       <span class="dst">{{dst}}</span>
       <span class="val">{{count}}</span><span class="val">{{pct}}</span>
     </div>
+    {{/each}}
     {{/each}}
   </div>
   {{/if}}
@@ -335,7 +316,7 @@
   <div class="tbl" style="top:{{metadataTop}}pt;">
     <div class="thead"><span class="title">{{../t.metadata}}</span></div>
     {{#each ../metadataRows}}
-    <div class="trow meta"><span class="label">{{label}}</span><span class="value">{{value}}</span></div>
+    <div class="trow meta" data-mk="{{mk}}"><span class="label">{{label}}</span><span class="value">{{value}}</span></div>
     {{/each}}
   </div>
   {{/if}}


### PR DESCRIPTION


Reduce row padding so the page 1 warnings table clears the footer (0.6pt to 25pt) and give the footer a reserved white band.

Render the three Mappings tables as one table with per-group sub-headers, so Education level, Electricity and Connectivity read as a single unit.

Let the Metadata table stay on page 2 when it fits below the mappings, instead of always starting a new page.

Replace the char-count height heuristics with a model derived from the CSS box, and repaginate from row heights measured in a first render pass so wrapped labels no longer overflow the page.
